### PR TITLE
Add temporary simulated WPMs in UserInfo

### DIFF
--- a/frontend/src/UserInfo.tsx
+++ b/frontend/src/UserInfo.tsx
@@ -11,6 +11,7 @@ interface UserInfoState {
 }
 
 class UserInfo extends Component<UserInfoProps, UserInfoState> {
+    interval: any;
 
     constructor(props: any) {
         super(props);
@@ -19,11 +20,26 @@ class UserInfo extends Component<UserInfoProps, UserInfoState> {
             currWpm: 100,
             currTab: "Google Drive",
         };
+        this.interval = null;
+    }
+
+    getWpm() {
+        this.setState(state => ({
+            currWpm: Math.floor(Math.random() * 70) + 50 // hard-coded random WPM for now
+        }));
     }
     
+    componentDidMount() {
+        this.interval = setInterval(() => this.getWpm(), 2000);
+    }
+
+    componentWillUnmount() {
+        clearInterval(this.interval);
+    }
+
     render() {
         return (
-            <Card title={this.props.name} style={{width: 300}}>
+            <Card title={this.props.name} style={{width: 200}}>
                 <p>WPM: {this.state.currWpm}</p>
                 <p>Current tab: {this.state.currTab}</p>
             </Card>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,8 +3,8 @@
 body {
     font: 14px "Century Gothic", Futura, sans-serif;
     margin: 20px;
-    width: 600px;
-    height: 400px;
+    width: 300px;
+    height: 300px;
   }
   
   ol, ul {


### PR DESCRIPTION
For purposes of user testing, this merge request adds hardcoded values simulating the WPM of another person in a 'room' has been added to the UserInfo component of the Chrome extension.

![Animation](https://user-images.githubusercontent.com/11587787/155456560-133553ce-2cda-454e-9370-a7c83712366e.gif)

